### PR TITLE
fix: ロゴからトップページへ遷移できるようにする

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -4,5 +4,7 @@
     class="flex items-center justify-center p-2 h-16 text-2xl sm:text-3xl font-bold shadow-md
                z-30 sticky top-0 bg-gradient-to-r from-emerald-300 via-green-300 to-cyan-300"
 >
+    <a href="/" aria-label="トップページへ戻る">
         <img src="/logo.avif" alt="logo" width="200" class="mt-1 mr-3" />
+    </a>
 </header>


### PR DESCRIPTION
## 概要
- ヘッダーのロゴ画像をトップページ (`/`) へのリンクに変更
- ロゴクリックで常にトップへ戻れるように改善

## 変更内容
- `src/components/header.astro` のロゴ画像を `<a href="/">` でラップ
- `aria-label` を追加してリンクの意図を明示

## 動作確認
- [x] ロゴをクリックすると `/` へ遷移すること
- [ ] `bun run check`（`biome: command not found` のためこの環境では未実施）
