### PR TITLE
test: add coverage for seo markdown posts and rss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run check
+        run: bun run check:ci
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run test
+        run: bun test

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
   "assist": {
     "actions": {
       "source": {
@@ -24,6 +24,11 @@
     "formatter": {
       "indentWidth": 2,
       "quoteStyle": "double"
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
     }
   },
   "linter": {

--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
         "@tailwindcss/typography": "0.5.19",
         "@tailwindcss/vite": "4.2.1",
         "@types/sanitize-html": "2.16.0",
+        "bun-types": "^1.3.10",
         "open-graph-scraper": "6.11.0",
         "sanitize-html": "2.17.1",
         "tailwindcss": "4.2.1",
@@ -609,6 +610,8 @@
     "budoux": ["budoux@0.7.0", "", { "dependencies": { "commander": "^13.0.0", "linkedom": "^0.18.7" }, "bin": { "budoux": "bin/budoux.js" } }, "sha512-3ozAqddyZUAYh9Lrk8eYcdBfVjplubOsF3NbwcHGIsfQ8An5+lwXQGw0KvrFN2mx1MP6SI+y6FoxuEqWaBZfjQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "astro preview",
     "deploy": "bun run build && wrangler deploy",
     "check": "biome check --write .",
+    "check:ci": "biome check .",
     "ensure:og-font": "bun run scripts/ensure-og-font.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "test": "bun test",
     "build": "bun run ensure:og-font && astro check && astro build",
     "preview": "astro preview",
     "deploy": "bun run build && wrangler deploy",
@@ -64,6 +65,7 @@
     "@tailwindcss/typography": "0.5.19",
     "@tailwindcss/vite": "4.2.1",
     "@types/sanitize-html": "2.16.0",
+    "bun-types": "^1.3.10",
     "open-graph-scraper": "6.11.0",
     "sanitize-html": "2.17.1",
     "tailwindcss": "4.2.1"

--- a/scripts/ensure-og-font.mjs
+++ b/scripts/ensure-og-font.mjs
@@ -31,7 +31,9 @@ async function downloadFont() {
 
   const buffer = new Uint8Array(await response.arrayBuffer());
   if (buffer.byteLength < MIN_FONT_SIZE) {
-    throw new Error(`Downloaded font looks too small (${buffer.byteLength} bytes)`);
+    throw new Error(
+      `Downloaded font looks too small (${buffer.byteLength} bytes)`,
+    );
   }
 
   await mkdir(dirname(FONT_PATH), { recursive: true });

--- a/src/components/shadcn/card.tsx
+++ b/src/components/shadcn/card.tsx
@@ -42,9 +42,9 @@ export function BlogCardComponent(props: BlogCardComponentProps) {
         </a>
       </CardHeader>
       <CardContent>
-        {props.tags.map((tag, index) => (
+        {props.tags.map((tag) => (
           <a
-            key={`${props.slug || props.url}-${tag}-${index}`}
+            key={`${props.slug || props.url}-${tag}`}
             href={`https://yashikota.com/blog/tags/${tag.toLocaleLowerCase()}/`}
           >
             <span className="mr-2 text-sky-400 hover:text-sky-700">#{tag}</span>

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,33 +1,53 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { markdownToHtmlWithToc } from "./markdown";
 
+const originalFetch = globalThis.fetch;
+const linkPreviewApiPrefix =
+  "https://linkpreview-api.yashikota.workers.dev/preview?url=";
+
+function toUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
 describe("markdownToHtmlWithToc", () => {
-  test("renders headings, TOC, and external link attributes", async () => {
-    const markdown = [
-      "## Section A",
-      "",
-      "本文のリンクは[Example](https://example.com)です。",
-      "",
-      "### Section B",
-      "",
-      "`inline` text",
-    ].join("\n");
+  test("builds TOC from h2/h3 and appends heading copy button", async () => {
+    const markdown = ["# Title", "", "## Section A", "", "### Section B"].join(
+      "\n",
+    );
 
     const { html, toc } = await markdownToHtmlWithToc(markdown);
 
+    expect(html).toContain('<h1 id="title">');
     expect(html).toContain('<h2 id="section-a">');
     expect(html).toContain('<h3 id="section-b">');
     expect(html).toContain("markdown-copy-link-btn");
+
+    expect(toc).toContain('href="#section-a"');
+    expect(toc).toContain('href="#section-b"');
+    expect(toc).not.toContain('href="#title"');
+  });
+
+  test("adds noreferrer for external links", async () => {
+    const { html } = await markdownToHtmlWithToc("[site](https://example.com)");
+
     expect(html).toContain('href="https://example.com"');
     expect(html).toContain('target="_blank"');
     expect(html).toContain('rel="noreferrer"');
-
-    expect(toc).toContain('class="toc-nav"');
-    expect(toc).toContain('href="#section-a"');
-    expect(toc).toContain('href="#section-b"');
   });
 
-  test("does not add noreferrer to yashikota.com links", async () => {
+  test("does not add noreferrer for yashikota.com links", async () => {
     const { html } = await markdownToHtmlWithToc(
       "[site](https://yashikota.com)",
     );
@@ -37,11 +57,150 @@ describe("markdownToHtmlWithToc", () => {
     expect(html).not.toContain('rel="noreferrer"');
   });
 
-  test("returns an empty TOC list when no h2/h3 exists", async () => {
-    const { toc } = await markdownToHtmlWithToc("plain text only");
+  test("supports image width suffix and caption", async () => {
+    const markdown = [
+      "![alt](https://example.com/image.png#250px)",
+      "*caption text*",
+    ].join("\n");
 
-    expect(toc).toContain('class="toc-nav"');
-    expect(toc).not.toContain("toc-link-h2");
-    expect(toc).not.toContain("toc-link-h3");
+    const { html } = await markdownToHtmlWithToc(markdown);
+
+    expect(html).toContain("<figure>");
+    expect(html).toContain('src="https://example.com/image.png"');
+    expect(html).toContain('width="250px"');
+    expect(html).toContain("<figcaption>caption text</figcaption>");
+  });
+
+  test("supports GFM table and task list", async () => {
+    const markdown = [
+      "| A | B |",
+      "| - | - |",
+      "| 1 | 2 |",
+      "",
+      "- [x] done",
+      "- [ ] todo",
+    ].join("\n");
+
+    const { html } = await markdownToHtmlWithToc(markdown);
+
+    expect(html).toContain("<table>");
+    expect(html).toContain("<thead>");
+    expect(html).toContain("<tbody>");
+    expect(html).toContain("contains-task-list");
+    expect(html).toContain("task-list-item");
+  });
+
+  test("renders block and inline math via KaTeX", async () => {
+    const markdown = [
+      "$a\\ne0$",
+      "",
+      "$$",
+      "e^{i\\theta}=\\cos\\theta+i\\sin\\theta",
+      "$$",
+    ].join("\n");
+
+    const { html } = await markdownToHtmlWithToc(markdown);
+
+    expect(html).toContain("katex-display");
+    expect(html).toContain("katex-mathml");
+    expect(html).toContain("katex-html");
+  });
+
+  test("supports footnotes", async () => {
+    const markdown = ["Footnote[^1]", "", "[^1]: Footnote body"].join("\n");
+
+    const { html } = await markdownToHtmlWithToc(markdown);
+
+    expect(html).toContain("data-footnote-ref");
+    expect(html).toContain("data-footnotes");
+    expect(html).toContain("footnote-backref");
+  });
+
+  test("supports GitHub-style blockquote alerts", async () => {
+    const markdown = ["> [!NOTE]", "> note", "", "> [!WARNING]", "> warn"].join(
+      "\n",
+    );
+
+    const { html } = await markdownToHtmlWithToc(markdown);
+
+    expect(html).toContain("markdown-alert markdown-alert-note");
+    expect(html).toContain("markdown-alert markdown-alert-warning");
+    expect(html).toContain("markdown-alert-title");
+  });
+
+  test("embeds YouTube URLs", async () => {
+    const { html } = await markdownToHtmlWithToc(
+      "https://youtu.be/enTFE2c68FQ",
+    );
+
+    expect(html).toContain("youtube-wrapper");
+    expect(html).toContain("youtube-iframe");
+    expect(html).toContain("https://www.youtube.com/embed/enTFE2c68FQ");
+  });
+
+  test("embeds video URLs", async () => {
+    const { html } = await markdownToHtmlWithToc(
+      "https://example.com/demo.mp4",
+    );
+
+    expect(html).toContain("<video");
+    expect(html).toContain('src="https://example.com/demo.mp4"');
+  });
+
+  test("renders link cards for URL-only paragraphs", async () => {
+    const fetchCalls: string[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = toUrl(input);
+      fetchCalls.push(url);
+
+      if (url.startsWith(linkPreviewApiPrefix)) {
+        return new Response(
+          JSON.stringify({
+            title: "Preview title",
+            description: "Preview description",
+            favicon: "https://example.com/favicon.ico",
+            ogImage: "https://example.com/og.png",
+          }),
+          {
+            headers: {
+              "Content-Type": "application/json",
+            },
+            status: 200,
+          },
+        );
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    const { html } = await markdownToHtmlWithToc("https://example.com/page");
+
+    expect(fetchCalls.length).toBeGreaterThan(0);
+    expect(fetchCalls[0]).toContain(linkPreviewApiPrefix);
+    expect(html).toContain("remark-link-card-plus__container");
+    expect(html).toContain("Preview title");
+    expect(html).toContain("Preview description");
+    expect(html).toContain('class="remark-link-card-plus__url">example.com');
+  });
+
+  test("applies expressive code rendering including mermaid block", async () => {
+    const markdown = [
+      "```mermaid",
+      "graph TB",
+      "A-->B",
+      "```",
+      "",
+      "```js",
+      'console.log("x");',
+      "```",
+    ].join("\n");
+
+    const { html } = await markdownToHtmlWithToc(markdown);
+
+    expect(html).toContain("expressive-code");
+    expect(html).toContain('data-language="mermaid"');
+    expect(html).toContain('data-language="js"');
+    expect(html).toContain("console.log");
   });
 });

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { markdownToHtmlWithToc } from "./markdown";
+
+describe("markdownToHtmlWithToc", () => {
+  test("renders headings, TOC, and external link attributes", async () => {
+    const markdown = [
+      "## Section A",
+      "",
+      "本文のリンクは[Example](https://example.com)です。",
+      "",
+      "### Section B",
+      "",
+      "`inline` text",
+    ].join("\n");
+
+    const { html, toc } = await markdownToHtmlWithToc(markdown);
+
+    expect(html).toContain('<h2 id="section-a">');
+    expect(html).toContain('<h3 id="section-b">');
+    expect(html).toContain("markdown-copy-link-btn");
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noreferrer"');
+
+    expect(toc).toContain('class="toc-nav"');
+    expect(toc).toContain('href="#section-a"');
+    expect(toc).toContain('href="#section-b"');
+  });
+
+  test("does not add noreferrer to yashikota.com links", async () => {
+    const { html } = await markdownToHtmlWithToc(
+      "[site](https://yashikota.com)",
+    );
+
+    expect(html).toContain('href="https://yashikota.com"');
+    expect(html).toContain('target="_blank"');
+    expect(html).not.toContain('rel="noreferrer"');
+  });
+
+  test("returns an empty TOC list when no h2/h3 exists", async () => {
+    const { toc } = await markdownToHtmlWithToc("plain text only");
+
+    expect(toc).toContain('class="toc-nav"');
+    expect(toc).not.toContain("toc-link-h2");
+    expect(toc).not.toContain("toc-link-h3");
+  });
+});

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -56,28 +56,25 @@ type PostsModule = typeof import("./posts");
 type TechRssModule = typeof import("../pages/rss/tech.xml");
 type LifeRssModule = typeof import("../pages/rss/life.xml");
 
-async function importPostsModule(): Promise<PostsModule> {
+async function importWithCacheBust<T>(modulePath: string): Promise<T> {
   const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  const moduleUrl = new URL(`./posts.ts?test=${cacheBuster}`, import.meta.url);
-  return (await import(moduleUrl.href)) as PostsModule;
+  const moduleUrl = new URL(
+    `${modulePath}?test=${cacheBuster}`,
+    import.meta.url,
+  );
+  return (await import(moduleUrl.href)) as T;
+}
+
+async function importPostsModule(): Promise<PostsModule> {
+  return importWithCacheBust<PostsModule>("./posts.ts");
 }
 
 async function importTechRssModule(): Promise<TechRssModule> {
-  const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  const moduleUrl = new URL(
-    `../pages/rss/tech.xml?test=${cacheBuster}`,
-    import.meta.url,
-  );
-  return (await import(moduleUrl.href)) as TechRssModule;
+  return importWithCacheBust<TechRssModule>("../pages/rss/tech.xml");
 }
 
 async function importLifeRssModule(): Promise<LifeRssModule> {
-  const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  const moduleUrl = new URL(
-    `../pages/rss/life.xml?test=${cacheBuster}`,
-    import.meta.url,
-  );
-  return (await import(moduleUrl.href)) as LifeRssModule;
+  return importWithCacheBust<LifeRssModule>("../pages/rss/life.xml");
 }
 
 function toUrl(input: RequestInfo | URL): string {
@@ -108,6 +105,17 @@ function textResponse(data: string): Response {
     },
     status: 200,
   });
+}
+
+function mockEmptyZennFetch(): void {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = toUrl(input);
+    if (url.startsWith("https://zenn.dev/api/articles")) {
+      return jsonResponse({ articles: [] });
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  }) as typeof fetch;
 }
 
 beforeEach(() => {
@@ -273,159 +281,147 @@ describe("posts", () => {
     expect("body" in posts[0]).toBe(false);
   });
 
-  test("tech RSS includes only listed tech posts", async () => {
-    const techRssModule = await importTechRssModule();
+  describe("rss routes", () => {
+    beforeEach(() => {
+      mockEmptyZennFetch();
+    });
 
-    blogCollectionEntries = [
-      {
-        id: "tech-visible",
-        body: "",
-        data: {
-          title: "Tech visible",
-          pubDate: new Date("2025-05-01T00:00:00.000Z"),
-          updDate: null,
-          isUnlisted: false,
-          category: "tech",
-          tags: [],
-          showToc: false,
-        },
-      },
-      {
-        id: "tech-hidden",
-        body: "",
-        data: {
-          title: "Tech hidden",
-          pubDate: new Date("2025-05-02T00:00:00.000Z"),
-          updDate: null,
-          isUnlisted: true,
-          category: "tech",
-          tags: [],
-          showToc: false,
-        },
-      },
-      {
-        id: "life-visible",
-        body: "",
-        data: {
-          title: "Life visible",
-          pubDate: new Date("2025-05-03T00:00:00.000Z"),
-          updDate: null,
-          isUnlisted: false,
-          category: "life",
-          tags: [],
-          showToc: false,
-        },
-      },
-    ];
+    test("tech RSS includes only listed tech posts", async () => {
+      const techRssModule = await importTechRssModule();
 
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-      const url = toUrl(input);
-      if (url.startsWith("https://zenn.dev/api/articles")) {
-        return jsonResponse({ articles: [] });
+      blogCollectionEntries = [
+        {
+          id: "tech-visible",
+          body: "",
+          data: {
+            title: "Tech visible",
+            pubDate: new Date("2025-05-01T00:00:00.000Z"),
+            updDate: null,
+            isUnlisted: false,
+            category: "tech",
+            tags: [],
+            showToc: false,
+          },
+        },
+        {
+          id: "tech-hidden",
+          body: "",
+          data: {
+            title: "Tech hidden",
+            pubDate: new Date("2025-05-02T00:00:00.000Z"),
+            updDate: null,
+            isUnlisted: true,
+            category: "tech",
+            tags: [],
+            showToc: false,
+          },
+        },
+        {
+          id: "life-visible",
+          body: "",
+          data: {
+            title: "Life visible",
+            pubDate: new Date("2025-05-03T00:00:00.000Z"),
+            updDate: null,
+            isUnlisted: false,
+            category: "life",
+            tags: [],
+            showToc: false,
+          },
+        },
+      ];
+
+      await techRssModule.GET();
+
+      expect(capturedRssInput).not.toBeNull();
+      if (!capturedRssInput) {
+        return;
       }
 
-      throw new Error(`Unexpected fetch URL: ${url}`);
-    }) as typeof fetch;
+      expect(capturedRssInput.title).toBe("Tech Blog - yashikota.com");
+      expect(capturedRssInput.description).toBe(
+        "Tech blog posts from yashikota.com",
+      );
+      expect(capturedRssInput.site).toBe("https://yashikota.com");
 
-    await techRssModule.GET();
+      const items = capturedRssInput.items as Array<{
+        title: string;
+        pubDate: Date;
+        link: string;
+      }>;
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toBe("Tech visible");
+      expect(items[0].pubDate).toBeInstanceOf(Date);
+      expect(items[0].link).toBe("/blog/tech-visible");
+    });
 
-    expect(capturedRssInput).not.toBeNull();
-    if (!capturedRssInput) {
-      return;
-    }
+    test("life RSS includes only listed life posts", async () => {
+      const lifeRssModule = await importLifeRssModule();
 
-    expect(capturedRssInput.title).toBe("Tech Blog - yashikota.com");
-    expect(capturedRssInput.description).toBe(
-      "Tech blog posts from yashikota.com",
-    );
-    expect(capturedRssInput.site).toBe("https://yashikota.com");
-
-    const items = capturedRssInput.items as Array<{
-      title: string;
-      pubDate: Date;
-      link: string;
-    }>;
-    expect(items).toHaveLength(1);
-    expect(items[0].title).toBe("Tech visible");
-    expect(items[0].pubDate).toBeInstanceOf(Date);
-    expect(items[0].link).toBe("/blog/tech-visible");
-  });
-
-  test("life RSS includes only listed life posts", async () => {
-    const lifeRssModule = await importLifeRssModule();
-
-    blogCollectionEntries = [
-      {
-        id: "tech-visible",
-        body: "",
-        data: {
-          title: "Tech visible",
-          pubDate: new Date("2025-05-01T00:00:00.000Z"),
-          updDate: null,
-          isUnlisted: false,
-          category: "tech",
-          tags: [],
-          showToc: false,
+      blogCollectionEntries = [
+        {
+          id: "tech-visible",
+          body: "",
+          data: {
+            title: "Tech visible",
+            pubDate: new Date("2025-05-01T00:00:00.000Z"),
+            updDate: null,
+            isUnlisted: false,
+            category: "tech",
+            tags: [],
+            showToc: false,
+          },
         },
-      },
-      {
-        id: "life-hidden",
-        body: "",
-        data: {
-          title: "Life hidden",
-          pubDate: new Date("2025-05-02T00:00:00.000Z"),
-          updDate: null,
-          isUnlisted: true,
-          category: "life",
-          tags: [],
-          showToc: false,
+        {
+          id: "life-hidden",
+          body: "",
+          data: {
+            title: "Life hidden",
+            pubDate: new Date("2025-05-02T00:00:00.000Z"),
+            updDate: null,
+            isUnlisted: true,
+            category: "life",
+            tags: [],
+            showToc: false,
+          },
         },
-      },
-      {
-        id: "life-visible",
-        body: "",
-        data: {
-          title: "Life visible",
-          pubDate: new Date("2025-05-03T00:00:00.000Z"),
-          updDate: null,
-          isUnlisted: false,
-          category: "life",
-          tags: [],
-          showToc: false,
+        {
+          id: "life-visible",
+          body: "",
+          data: {
+            title: "Life visible",
+            pubDate: new Date("2025-05-03T00:00:00.000Z"),
+            updDate: null,
+            isUnlisted: false,
+            category: "life",
+            tags: [],
+            showToc: false,
+          },
         },
-      },
-    ];
+      ];
 
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-      const url = toUrl(input);
-      if (url.startsWith("https://zenn.dev/api/articles")) {
-        return jsonResponse({ articles: [] });
+      await lifeRssModule.GET();
+
+      expect(capturedRssInput).not.toBeNull();
+      if (!capturedRssInput) {
+        return;
       }
 
-      throw new Error(`Unexpected fetch URL: ${url}`);
-    }) as typeof fetch;
+      expect(capturedRssInput.title).toBe("Life Blog - yashikota.com");
+      expect(capturedRssInput.description).toBe(
+        "Life blog posts from yashikota.com",
+      );
+      expect(capturedRssInput.site).toBe("https://yashikota.com");
 
-    await lifeRssModule.GET();
-
-    expect(capturedRssInput).not.toBeNull();
-    if (!capturedRssInput) {
-      return;
-    }
-
-    expect(capturedRssInput.title).toBe("Life Blog - yashikota.com");
-    expect(capturedRssInput.description).toBe(
-      "Life blog posts from yashikota.com",
-    );
-    expect(capturedRssInput.site).toBe("https://yashikota.com");
-
-    const items = capturedRssInput.items as Array<{
-      title: string;
-      pubDate: Date;
-      link: string;
-    }>;
-    expect(items).toHaveLength(1);
-    expect(items[0].title).toBe("Life visible");
-    expect(items[0].pubDate).toBeInstanceOf(Date);
-    expect(items[0].link).toBe("/blog/life-visible");
+      const items = capturedRssInput.items as Array<{
+        title: string;
+        pubDate: Date;
+        link: string;
+      }>;
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toBe("Life visible");
+      expect(items[0].pubDate).toBeInstanceOf(Date);
+      expect(items[0].link).toBe("/blog/life-visible");
+    });
   });
 });

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { getFaviconUrl } from "./utils";
+
+type BlogCollectionEntry = {
+  id: string;
+  body: string;
+  data: {
+    title: string;
+    pubDate: Date;
+    updDate: Date | null;
+    isUnlisted: boolean;
+    category: "tech" | "life";
+    tags: string[];
+    showToc: boolean;
+  };
+};
+
+let blogCollectionEntries: BlogCollectionEntry[] = [];
+
+const externalPostsFixture = [
+  {
+    title: "External entry",
+    pubDate: "2025-04-01",
+    updDate: null,
+    tags: ["External"],
+    url: "https://external.example.com/posts/1",
+  },
+];
+
+mock.module("astro:content", () => ({
+  getCollection: async (name: string) => {
+    if (name !== "blog") {
+      return [];
+    }
+
+    return blogCollectionEntries;
+  },
+}));
+
+mock.module("@/data/posts.json", () => ({
+  default: externalPostsFixture,
+}));
+
+let capturedRssInput: Record<string, unknown> | null = null;
+
+mock.module("@astrojs/rss", () => ({
+  default: (input: Record<string, unknown>) => {
+    capturedRssInput = input;
+    return input;
+  },
+}));
+
+const originalFetch = globalThis.fetch;
+
+type PostsModule = typeof import("./posts");
+type TechRssModule = typeof import("../pages/rss/tech.xml");
+type LifeRssModule = typeof import("../pages/rss/life.xml");
+
+async function importPostsModule(): Promise<PostsModule> {
+  const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const moduleUrl = new URL(`./posts.ts?test=${cacheBuster}`, import.meta.url);
+  return (await import(moduleUrl.href)) as PostsModule;
+}
+
+async function importTechRssModule(): Promise<TechRssModule> {
+  const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const moduleUrl = new URL(
+    `../pages/rss/tech.xml?test=${cacheBuster}`,
+    import.meta.url,
+  );
+  return (await import(moduleUrl.href)) as TechRssModule;
+}
+
+async function importLifeRssModule(): Promise<LifeRssModule> {
+  const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const moduleUrl = new URL(
+    `../pages/rss/life.xml?test=${cacheBuster}`,
+    import.meta.url,
+  );
+  return (await import(moduleUrl.href)) as LifeRssModule;
+}
+
+function toUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status: 200,
+  });
+}
+
+function textResponse(data: string): Response {
+  return new Response(data, {
+    headers: {
+      "Content-Type": "text/html",
+    },
+    status: 200,
+  });
+}
+
+beforeEach(() => {
+  capturedRssInput = null;
+  blogCollectionEntries = [
+    {
+      id: "blog-alpha",
+      body: "alpha body",
+      data: {
+        title: "Alpha",
+        pubDate: new Date("2025-01-02T00:00:00.000Z"),
+        updDate: new Date("2025-01-05T00:00:00.000Z"),
+        isUnlisted: false,
+        category: "tech",
+        tags: ["Astro"],
+        showToc: true,
+      },
+    },
+    {
+      id: "blog-beta",
+      body: "beta body",
+      data: {
+        title: "Beta",
+        pubDate: new Date("2024-12-31T00:00:00.000Z"),
+        updDate: null,
+        isUnlisted: true,
+        category: "life",
+        tags: [],
+        showToc: false,
+      },
+    },
+  ];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("posts", () => {
+  test("getBlogPosts maps Astro collection entries", async () => {
+    const postsModule = await importPostsModule();
+    const posts = await postsModule.getBlogPosts();
+
+    expect(posts).toHaveLength(2);
+    expect(posts[0]).toEqual({
+      title: "Alpha",
+      pubDate: "2025-01-02",
+      updDate: "2025-01-05",
+      isUnlisted: false,
+      category: "tech",
+      tags: ["Astro"],
+      slug: "blog-alpha",
+      body: "alpha body",
+      url: "/blog/blog-alpha",
+      icon: getFaviconUrl("yashikota.com"),
+      showToc: true,
+    });
+    expect(posts[1].updDate).toBeNull();
+  });
+
+  test("getExternalPosts maps static JSON entries", async () => {
+    const postsModule = await importPostsModule();
+    const posts = await postsModule.getExternalPosts();
+
+    expect(posts).toEqual([
+      {
+        title: "External entry",
+        pubDate: "2025-04-01",
+        updDate: null,
+        tags: ["External"],
+        url: "https://external.example.com/posts/1",
+        slug: "",
+        icon: getFaviconUrl("https://external.example.com"),
+      },
+    ]);
+  });
+
+  test("getZennPosts fetches articles and extracts topic tags", async () => {
+    const postsModule = await importPostsModule();
+    const fetchCalls: string[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = toUrl(input);
+      fetchCalls.push(url);
+
+      if (url.startsWith("https://zenn.dev/api/articles")) {
+        return jsonResponse({
+          articles: [
+            {
+              title: "Zenn article",
+              published_at: "2025-03-02T10:00:00.000Z",
+              body_updated_at: "2025-03-02T11:00:00.000Z",
+              path: "/articles/bun-test",
+            },
+          ],
+        });
+      }
+
+      if (url === "https://zenn.dev/articles/bun-test") {
+        return textResponse(
+          '<div class="TopicList_name__abc">TypeScript</div><div class="TopicList_name__xyz">Astro</div>',
+        );
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    const posts = await postsModule.getZennPosts();
+
+    expect(fetchCalls[0]).toContain("https://zenn.dev/api/articles");
+    expect(fetchCalls[1]).toBe("https://zenn.dev/articles/bun-test");
+    expect(posts).toEqual([
+      {
+        title: "Zenn article",
+        pubDate: "2025-03-02",
+        updDate: null,
+        category: "tech",
+        tags: ["TypeScript", "Astro"],
+        slug: "",
+        url: "https://zenn.dev/articles/bun-test",
+        icon: getFaviconUrl("https://zenn.dev"),
+      },
+    ]);
+  });
+
+  test("getAllPosts merges sources and sorts by newest pubDate", async () => {
+    const postsModule = await importPostsModule();
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = toUrl(input);
+
+      if (url.startsWith("https://zenn.dev/api/articles")) {
+        return jsonResponse({
+          articles: [
+            {
+              title: "Zenn article",
+              published_at: "2025-03-02T10:00:00.000Z",
+              body_updated_at: "2025-03-03T10:00:00.000Z",
+              path: "/articles/bun-test",
+            },
+          ],
+        });
+      }
+
+      if (url === "https://zenn.dev/articles/bun-test") {
+        return textResponse(
+          '<div class="TopicList_name__abc">TypeScript</div>',
+        );
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    const posts = await postsModule.getAllPosts();
+
+    expect(posts.map((post) => post.title)).toEqual([
+      "External entry",
+      "Zenn article",
+      "Alpha",
+      "Beta",
+    ]);
+    expect(posts[0].pubDate).toBe("2025-04-01");
+    expect(posts[1].updDate).toBe("2025-03-03");
+    expect("body" in posts[0]).toBe(false);
+  });
+
+  test("tech RSS includes only listed tech posts", async () => {
+    const techRssModule = await importTechRssModule();
+
+    blogCollectionEntries = [
+      {
+        id: "tech-visible",
+        body: "",
+        data: {
+          title: "Tech visible",
+          pubDate: new Date("2025-05-01T00:00:00.000Z"),
+          updDate: null,
+          isUnlisted: false,
+          category: "tech",
+          tags: [],
+          showToc: false,
+        },
+      },
+      {
+        id: "tech-hidden",
+        body: "",
+        data: {
+          title: "Tech hidden",
+          pubDate: new Date("2025-05-02T00:00:00.000Z"),
+          updDate: null,
+          isUnlisted: true,
+          category: "tech",
+          tags: [],
+          showToc: false,
+        },
+      },
+      {
+        id: "life-visible",
+        body: "",
+        data: {
+          title: "Life visible",
+          pubDate: new Date("2025-05-03T00:00:00.000Z"),
+          updDate: null,
+          isUnlisted: false,
+          category: "life",
+          tags: [],
+          showToc: false,
+        },
+      },
+    ];
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = toUrl(input);
+      if (url.startsWith("https://zenn.dev/api/articles")) {
+        return jsonResponse({ articles: [] });
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    await techRssModule.GET();
+
+    expect(capturedRssInput).not.toBeNull();
+    if (!capturedRssInput) {
+      return;
+    }
+
+    expect(capturedRssInput.title).toBe("Tech Blog - yashikota.com");
+    expect(capturedRssInput.description).toBe(
+      "Tech blog posts from yashikota.com",
+    );
+    expect(capturedRssInput.site).toBe("https://yashikota.com");
+
+    const items = capturedRssInput.items as Array<{
+      title: string;
+      pubDate: Date;
+      link: string;
+    }>;
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("Tech visible");
+    expect(items[0].pubDate).toBeInstanceOf(Date);
+    expect(items[0].link).toBe("/blog/tech-visible");
+  });
+
+  test("life RSS includes only listed life posts", async () => {
+    const lifeRssModule = await importLifeRssModule();
+
+    blogCollectionEntries = [
+      {
+        id: "tech-visible",
+        body: "",
+        data: {
+          title: "Tech visible",
+          pubDate: new Date("2025-05-01T00:00:00.000Z"),
+          updDate: null,
+          isUnlisted: false,
+          category: "tech",
+          tags: [],
+          showToc: false,
+        },
+      },
+      {
+        id: "life-hidden",
+        body: "",
+        data: {
+          title: "Life hidden",
+          pubDate: new Date("2025-05-02T00:00:00.000Z"),
+          updDate: null,
+          isUnlisted: true,
+          category: "life",
+          tags: [],
+          showToc: false,
+        },
+      },
+      {
+        id: "life-visible",
+        body: "",
+        data: {
+          title: "Life visible",
+          pubDate: new Date("2025-05-03T00:00:00.000Z"),
+          updDate: null,
+          isUnlisted: false,
+          category: "life",
+          tags: [],
+          showToc: false,
+        },
+      },
+    ];
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = toUrl(input);
+      if (url.startsWith("https://zenn.dev/api/articles")) {
+        return jsonResponse({ articles: [] });
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    await lifeRssModule.GET();
+
+    expect(capturedRssInput).not.toBeNull();
+    if (!capturedRssInput) {
+      return;
+    }
+
+    expect(capturedRssInput.title).toBe("Life Blog - yashikota.com");
+    expect(capturedRssInput.description).toBe(
+      "Life blog posts from yashikota.com",
+    );
+    expect(capturedRssInput.site).toBe("https://yashikota.com");
+
+    const items = capturedRssInput.items as Array<{
+      title: string;
+      pubDate: Date;
+      link: string;
+    }>;
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("Life visible");
+    expect(items[0].pubDate).toBeInstanceOf(Date);
+    expect(items[0].link).toBe("/blog/life-visible");
+  });
+});

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createDescriptionFromMarkdown,
+  DEFAULT_DESCRIPTION,
+  splitJapaneseText,
+  stripMarkdown,
+  toAbsoluteUrl,
+  truncateText,
+} from "./seo";
+
+const getCharDisplayWidth = (char: string): number => {
+  if (/\s/.test(char)) {
+    return 0.35;
+  }
+
+  if (/[\u0020-\u007e]/.test(char)) {
+    return 0.56;
+  }
+
+  return 1;
+};
+
+const getDisplayWidth = (value: string): number =>
+  Array.from(value).reduce(
+    (total, char) => total + getCharDisplayWidth(char),
+    0,
+  );
+
+describe("toAbsoluteUrl", () => {
+  test("resolves relative URL against provided base", () => {
+    const actual = toAbsoluteUrl("/blog", "https://example.com/base/");
+    expect(actual).toBe("https://example.com/blog");
+  });
+
+  test("keeps absolute URL as-is", () => {
+    const actual = toAbsoluteUrl(
+      "https://cdn.example.com/image.png",
+      "https://example.com",
+    );
+    expect(actual).toBe("https://cdn.example.com/image.png");
+  });
+});
+
+describe("stripMarkdown", () => {
+  test("removes markdown syntax and normalizes whitespace", () => {
+    const markdown = [
+      "# Heading",
+      "> quote line",
+      "Paragraph [link](https://example.com) ![img](https://example.com/x.png) `inline`",
+      "**bold** _italic_ ~~strike~~",
+      "```ts",
+      "const hidden = true;",
+      "```",
+    ].join("\n");
+
+    const actual = stripMarkdown(markdown);
+
+    expect(actual).toBe(
+      "Heading quote line Paragraph link inline bold italic strike",
+    );
+  });
+});
+
+describe("truncateText", () => {
+  test("returns original text when within limit", () => {
+    expect(truncateText("short", 10)).toBe("short");
+  });
+
+  test("adds ellipsis and trims trailing spaces", () => {
+    expect(truncateText("abc   def", 5)).toBe("abc…");
+  });
+});
+
+describe("createDescriptionFromMarkdown", () => {
+  test("uses default description when markdown has no text", () => {
+    expect(createDescriptionFromMarkdown("   \n\n")).toBe(DEFAULT_DESCRIPTION);
+  });
+
+  test("creates a truncated description from markdown", () => {
+    const actual = createDescriptionFromMarkdown("**Hello** world", 8);
+    expect(actual).toBe("Hello w…");
+  });
+});
+
+describe("splitJapaneseText", () => {
+  test("returns an empty array for blank input", () => {
+    expect(splitJapaneseText("   \n\t")).toEqual([]);
+  });
+
+  test("keeps each line within max width and line count", () => {
+    const lines = splitJapaneseText(
+      "これは Budoux を使った テキスト 分割 の テスト です",
+      2,
+      8,
+    );
+
+    expect(lines.length).toBeLessThanOrEqual(2);
+    for (const line of lines) {
+      expect(getDisplayWidth(line)).toBeLessThanOrEqual(8);
+    }
+  });
+
+  test("truncates a long ASCII word with ellipsis", () => {
+    const lines = splitJapaneseText("supercalifragilisticexpialidocious", 3, 8);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0].endsWith("…")).toBe(true);
+    expect(getDisplayWidth(lines[0])).toBeLessThanOrEqual(8);
+  });
+
+  test("caps output to maxLines for long text", () => {
+    const lines = splitJapaneseText("あ".repeat(30), 2, 5);
+
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(getDisplayWidth(line)).toBeLessThanOrEqual(5);
+    }
+  });
+});

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -2,29 +2,12 @@ import { describe, expect, test } from "bun:test";
 import {
   createDescriptionFromMarkdown,
   DEFAULT_DESCRIPTION,
+  getDisplayWidth,
   splitJapaneseText,
   stripMarkdown,
   toAbsoluteUrl,
   truncateText,
 } from "./seo";
-
-const getCharDisplayWidth = (char: string): number => {
-  if (/\s/.test(char)) {
-    return 0.35;
-  }
-
-  if (/[\u0020-\u007e]/.test(char)) {
-    return 0.56;
-  }
-
-  return 1;
-};
-
-const getDisplayWidth = (value: string): number =>
-  Array.from(value).reduce(
-    (total, char) => total + getCharDisplayWidth(char),
-    0,
-  );
 
 describe("toAbsoluteUrl", () => {
   test("resolves relative URL against provided base", () => {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -3,7 +3,8 @@ import { loadDefaultJapaneseParser } from "budoux";
 export const SITE_NAME = "こたのお考え";
 const DEFAULT_SITE_URL = "https://yashikota.com";
 const resolveSiteUrl = (): string => {
-  const envSiteUrl = import.meta.env.SITE_URL ?? import.meta.env.PUBLIC_SITE_URL;
+  const envSiteUrl =
+    import.meta.env.SITE_URL ?? import.meta.env.PUBLIC_SITE_URL;
   if (!envSiteUrl) {
     return DEFAULT_SITE_URL;
   }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -22,6 +22,25 @@ export const DEFAULT_DESCRIPTION = "こたのお考え";
 
 const parser = loadDefaultJapaneseParser();
 
+export function getCharDisplayWidth(char: string): number {
+  if (/\s/.test(char)) {
+    return 0.35;
+  }
+
+  if (/[\u0020-\u007e]/.test(char)) {
+    return 0.56;
+  }
+
+  return 1;
+}
+
+export function getDisplayWidth(value: string): number {
+  return Array.from(value).reduce(
+    (total, char) => total + getCharDisplayWidth(char),
+    0,
+  );
+}
+
 export function toAbsoluteUrl(
   value: string,
   baseUrl: string = SITE_URL,
@@ -87,24 +106,6 @@ export function splitJapaneseText(
 
   const isAsciiWord = (value: string): boolean =>
     /^[A-Za-z0-9][A-Za-z0-9'._-]*$/.test(value);
-
-  const getCharDisplayWidth = (char: string): number => {
-    if (/\s/.test(char)) {
-      return 0.35;
-    }
-
-    if (/[\u0020-\u007e]/.test(char)) {
-      return 0.56;
-    }
-
-    return 1;
-  };
-
-  const getDisplayWidth = (value: string): number =>
-    Array.from(value).reduce(
-      (total, char) => total + getCharDisplayWidth(char),
-      0,
-    );
 
   const truncateByDisplayWidth = (value: string, maxWidth: number): string => {
     if (getDisplayWidth(value) <= maxWidth) {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -14,7 +14,10 @@ let aboutMd = fs.readFileSync(aboutMdPath, "utf-8");
 const skillsXml = fs.readFileSync(skillsPath, "utf-8");
 
 // Inject skills.xml content into about.md
-aboutMd = aboutMd.replace("<!-- inject:skills -->", `\`\`\`xml\n${skillsXml}\`\`\``);
+aboutMd = aboutMd.replace(
+  "<!-- inject:skills -->",
+  `\`\`\`xml\n${skillsXml}\`\`\``,
+);
 
 const { html: aboutContent } = await markdownToHtmlWithToc(aboutMd);
 ---

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,9 +1,7 @@
 ---
-import Base from "@/layouts/base.astro";
-
 import { UpdateIcon } from "@radix-ui/react-icons";
-
 import { Blog } from "@/components/blog";
+import Base from "@/layouts/base.astro";
 import { markdownToHtmlWithToc } from "@/lib/markdown";
 import { getBlogPosts } from "@/lib/posts";
 import { createDescriptionFromMarkdown } from "@/lib/seo";

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,11 +1,9 @@
 ---
-import Base from "@/layouts/base.astro";
+import { HomeIcon } from "@radix-ui/react-icons";
 
 import { BlogCardComponent } from "@/components/shadcn/card";
-
+import Base from "@/layouts/base.astro";
 import { getAllPosts } from "@/lib/posts";
-
-import { HomeIcon } from "@radix-ui/react-icons";
 
 export async function getStaticPaths() {
   const allPosts = await getAllPosts();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "react",
+    "types": ["bun-types"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary
- add a Bun test script and Bun type definitions so test files pass TypeScript checks in `astro check`
- add focused tests for `src/lib/seo.ts` and `src/lib/markdown.ts` covering text normalization, truncation, TOC output, and external link handling
- add integration-style tests for `src/lib/posts.ts` and RSS routes to verify data mapping, sorting, and category/unlisted filtering with mocked dependencies

## Validation
- bun test
- bun run build