### PR TITLE
chore: enable wrangler preview URLs

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "name": "yashikota",
+  "preview_urls": true,
   "vars": {
     "BUN_VERSION": "1.3.3"
   },


### PR DESCRIPTION
## Summary
- Enable `preview_urls` in `wrangler.jsonc`
- Isolate this config change from the larger feature PR