### PR TITLE
fix: migrate Astro v6 content config and remove build warnings

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,4 +1,5 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
+import { z } from "astro/zod";
 import { glob } from "astro/loaders";
 
 const blogCollection = defineCollection({

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,6 @@
 import { defineCollection } from "astro:content";
-import { z } from "astro/zod";
 import { glob } from "astro/loaders";
+import { z } from "astro/zod";
 
 const blogCollection = defineCollection({
   loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/blog" }),

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -27,17 +27,6 @@ export async function getStaticPaths() {
 const { tag } = Astro.params;
 const { posts } = Astro.props;
 const canonicalUrl = `/blog/tags/${tag}/`;
-
-const getBackLink = () => {
-  const referrer = Astro.request.headers.get("referer");
-  if (!referrer) return "https://yashikota.com/blog#tech";
-
-  const url = new URL(referrer);
-  if (url.hash === "#life") {
-    return "https://yashikota.com/blog#life";
-  }
-  return "https://yashikota.com/blog#tech";
-};
 ---
 
 <Base
@@ -70,7 +59,8 @@ const getBackLink = () => {
     <div class="flex justify-center">
         <h2>
             <a
-                href={getBackLink()}
+                id="back-to-blog-link"
+                href="/blog#tech"
                 class="text-3xl font-bold text-green-500 flex items-center"
             >
                 <HomeIcon className="w-6 h-6 mr-2 mt-1" />
@@ -78,4 +68,20 @@ const getBackLink = () => {
             </a>
         </h2>
     </div>
+
+    <script>
+        const backLink = document.getElementById("back-to-blog-link");
+        if (backLink) {
+            try {
+                const referrer = document.referrer ? new URL(document.referrer) : null;
+                const isLifeTabReferrer =
+                    referrer?.pathname === "/blog" && referrer.hash === "#life";
+                if (isLifeTabReferrer) {
+                    backLink.setAttribute("href", "/blog#life");
+                }
+            } catch {
+                // Keep the default #tech anchor when referrer cannot be parsed.
+            }
+        }
+    </script>
 </Base>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -73,11 +73,14 @@ const canonicalUrl = `/blog/tags/${tag}/`;
         const backLink = document.getElementById("back-to-blog-link");
         if (backLink) {
             try {
-                const referrer = document.referrer ? new URL(document.referrer) : null;
-                const isLifeTabReferrer =
-                    referrer?.pathname === "/blog" && referrer.hash === "#life";
-                if (isLifeTabReferrer) {
-                    backLink.setAttribute("href", "/blog#life");
+                if (document.referrer) {
+                    const referrerUrl = new URL(document.referrer);
+                    if (
+                        referrerUrl.pathname === "/blog" &&
+                        referrerUrl.hash === "#life"
+                    ) {
+                        backLink.setAttribute("href", "/blog#life");
+                    }
                 }
             } catch {
                 // Keep the default #tech anchor when referrer cannot be parsed.


### PR DESCRIPTION
## Summary
- move content collection config from `src/content/config.ts` to `src/content.config.ts` for Astro v6
- replace deprecated `z` import with `astro/zod`
- remove `Astro.request.headers` usage on prerendered tag page by switching backlink logic to `document.referrer`

## Validation
- bun run build
  - astro check: 0 errors / 0 warnings / 0 hints
  - astro build: completed successfully