### PR TITLE
Add Standard.site support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "deploy": "bun run build && wrangler deploy",
     "check": "biome check --write .",
     "check:ci": "biome check .",
-    "ensure:og-font": "bun run scripts/ensure-og-font.mjs"
+    "ensure:og-font": "bun run scripts/ensure-og-font.mjs",
+    "standard-site:sync": "bun scripts/sync-standard-site.mjs"
   },
   "dependencies": {
     "@astrojs/check": "0.9.9",

--- a/scripts/sync-standard-site.mjs
+++ b/scripts/sync-standard-site.mjs
@@ -1,0 +1,405 @@
+#!/usr/bin/env bun
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { basename, extname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildStandardSiteDocumentRecord,
+  buildStandardSitePublicationRecord,
+  getStandardSiteDocumentRkey,
+  getSyncableStandardSitePosts,
+  STANDARD_SITE_DOCUMENT_COLLECTION,
+  STANDARD_SITE_PUBLICATION_COLLECTION,
+  STANDARD_SITE_PUBLICATION_RKEY,
+} from "../src/lib/standard-site.ts";
+
+const DEFAULT_SERVICE_URL = "https://bsky.social";
+const DEFAULT_SITE_URL = "https://yashikota.com";
+const DEFAULT_SITE_NAME = "こたのお考え";
+const DEFAULT_SITE_DESCRIPTION = "こたのお考え";
+const PREVIEW_PUBLICATION_URI =
+  "at://did:example:preview/site.standard.publication/self";
+
+const projectRoot = fileURLToPath(new URL("../", import.meta.url));
+const blogDirectory = join(projectRoot, "src/content/blog");
+const standardSiteDataPath = join(projectRoot, "src/data/standard-site.json");
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+
+function normalizeServiceUrl(value) {
+  return new URL(value).toString().replace(/\/+$/, "");
+}
+
+function readBooleanEnv(value, defaultValue) {
+  if (!value) {
+    return defaultValue;
+  }
+
+  return !["0", "false", "no"].includes(value.toLowerCase());
+}
+
+function parseScalar(rawValue) {
+  const value = rawValue.trim();
+
+  if (!value) {
+    return null;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return JSON.parse(value);
+  }
+
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return JSON.parse(value);
+  }
+
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+function parseFrontmatter(markdown, filePath) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(markdown);
+  if (!match) {
+    throw new Error(`Missing frontmatter: ${filePath}`);
+  }
+
+  const [, frontmatter, body] = match;
+  const data = {};
+
+  for (const line of frontmatter.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const field = /^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/.exec(line);
+    if (!field) {
+      throw new Error(`Unsupported frontmatter line in ${filePath}: ${line}`);
+    }
+
+    data[field[1]] = parseScalar(field[2] ?? "");
+  }
+
+  return { body, data };
+}
+
+function requireString(value, fieldName, filePath) {
+  if (typeof value !== "string" || !value) {
+    throw new Error(`Expected ${fieldName} to be a string in ${filePath}`);
+  }
+
+  return value;
+}
+
+function optionalDateString(value) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+
+  return String(value);
+}
+
+async function listMarkdownFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await listMarkdownFiles(entryPath)));
+      continue;
+    }
+
+    if (entry.isFile() && /\.(md|mdx)$/.test(entry.name)) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
+}
+
+async function readLocalBlogPosts() {
+  const files = await listMarkdownFiles(blogDirectory);
+  const posts = [];
+
+  for (const filePath of files) {
+    const markdown = await readFile(filePath, "utf8");
+    const { body, data } = parseFrontmatter(markdown, filePath);
+    const slug = relative(blogDirectory, filePath)
+      .slice(0, -extname(filePath).length)
+      .split(sep)
+      .join("/");
+
+    posts.push({
+      body,
+      category: data.category,
+      icon: undefined,
+      isUnlisted: data.isUnlisted === true,
+      pubDate: requireString(data.pubDate, "pubDate", filePath),
+      slug,
+      tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
+      title: requireString(data.title, "title", filePath),
+      updDate: optionalDateString(data.updDate),
+      url: `/blog/${slug}`,
+    });
+  }
+
+  return posts;
+}
+
+async function readStandardSiteData() {
+  try {
+    const rawData = JSON.parse(await readFile(standardSiteDataPath, "utf8"));
+    return {
+      documents:
+        rawData.documents && typeof rawData.documents === "object"
+          ? rawData.documents
+          : {},
+      publicationUri:
+        typeof rawData.publicationUri === "string"
+          ? rawData.publicationUri
+          : null,
+    };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {
+        documents: {},
+        publicationUri: null,
+      };
+    }
+
+    throw error;
+  }
+}
+
+async function writeStandardSiteData(data) {
+  const sortedDocuments = Object.fromEntries(
+    Object.entries(data.documents).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+
+  await writeFile(
+    standardSiteDataPath,
+    `${JSON.stringify(
+      {
+        documents: sortedDocuments,
+        publicationUri: data.publicationUri,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function postJson(serviceUrl, endpoint, payload, accessJwt) {
+  const headers = {
+    "Content-Type": "application/json",
+  };
+
+  if (accessJwt) {
+    headers.Authorization = `Bearer ${accessJwt}`;
+  }
+
+  const response = await fetch(`${serviceUrl}/xrpc/${endpoint}`, {
+    body: JSON.stringify(payload),
+    headers,
+    method: "POST",
+  });
+  const responseText = await response.text();
+  const responseJson = responseText ? JSON.parse(responseText) : {};
+
+  if (!response.ok) {
+    throw new Error(
+      `${endpoint} failed with ${response.status}: ${
+        responseJson.message ?? responseText
+      }`,
+    );
+  }
+
+  return responseJson;
+}
+
+async function createSession({ identifier, password, serviceUrl }) {
+  const session = await postJson(
+    serviceUrl,
+    "com.atproto.server.createSession",
+    {
+      identifier,
+      password,
+    },
+  );
+
+  if (!session.accessJwt || !session.did) {
+    throw new Error("PDS returned an incomplete AT Protocol session.");
+  }
+
+  return session;
+}
+
+async function putRecord({
+  accessJwt,
+  collection,
+  record,
+  repo,
+  rkey,
+  serviceUrl,
+}) {
+  const result = await postJson(
+    serviceUrl,
+    "com.atproto.repo.putRecord",
+    {
+      collection,
+      record,
+      repo,
+      rkey,
+    },
+    accessJwt,
+  );
+
+  if (!result.uri) {
+    throw new Error(`PDS did not return an AT-URI for ${collection}/${rkey}.`);
+  }
+
+  return result;
+}
+
+function resolvePublicationOptions() {
+  return {
+    description:
+      process.env.STANDARD_SITE_DESCRIPTION ?? DEFAULT_SITE_DESCRIPTION,
+    name: process.env.STANDARD_SITE_NAME ?? DEFAULT_SITE_NAME,
+    showInDiscover: readBooleanEnv(
+      process.env.STANDARD_SITE_SHOW_IN_DISCOVER,
+      true,
+    ),
+    siteUrl:
+      process.env.STANDARD_SITE_URL ??
+      process.env.SITE_URL ??
+      process.env.PUBLIC_SITE_URL ??
+      DEFAULT_SITE_URL,
+  };
+}
+
+function getPreviewRecord(record) {
+  const textContent = record.textContent ?? "";
+
+  return {
+    ...record,
+    textContent:
+      textContent.length > 200
+        ? `${textContent.slice(0, 200).trimEnd()}...`
+        : textContent,
+    textContentLength: textContent.length,
+  };
+}
+
+async function main() {
+  const serviceUrl = normalizeServiceUrl(
+    process.env.ATPROTO_SERVICE ?? DEFAULT_SERVICE_URL,
+  );
+  const existingData = await readStandardSiteData();
+  const posts = getSyncableStandardSitePosts(await readLocalBlogPosts());
+  const publicationRecord = buildStandardSitePublicationRecord(
+    resolvePublicationOptions(),
+  );
+
+  if (dryRun) {
+    const previewPublicationUri =
+      existingData.publicationUri ?? PREVIEW_PUBLICATION_URI;
+    const documentRecords = posts.map((post) => ({
+      collection: STANDARD_SITE_DOCUMENT_COLLECTION,
+      record: getPreviewRecord(
+        buildStandardSiteDocumentRecord({
+          post,
+          publicationUri: previewPublicationUri,
+        }),
+      ),
+      rkey: getStandardSiteDocumentRkey(post.slug),
+    }));
+
+    console.log(
+      JSON.stringify(
+        {
+          documents: documentRecords,
+          dryRun: true,
+          publication: {
+            collection: STANDARD_SITE_PUBLICATION_COLLECTION,
+            record: publicationRecord,
+            rkey: STANDARD_SITE_PUBLICATION_RKEY,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const identifier = process.env.ATPROTO_IDENTIFIER;
+  const password = process.env.ATPROTO_APP_PASSWORD;
+
+  if (!identifier || !password) {
+    throw new Error(
+      "Set ATPROTO_IDENTIFIER and ATPROTO_APP_PASSWORD before syncing Standard.site records.",
+    );
+  }
+
+  const session = await createSession({ identifier, password, serviceUrl });
+  console.log(`Authenticated as ${session.handle ?? session.did}`);
+
+  const publication = await putRecord({
+    accessJwt: session.accessJwt,
+    collection: STANDARD_SITE_PUBLICATION_COLLECTION,
+    record: publicationRecord,
+    repo: session.did,
+    rkey: STANDARD_SITE_PUBLICATION_RKEY,
+    serviceUrl,
+  });
+
+  const nextData = {
+    documents: {},
+    publicationUri: publication.uri,
+  };
+
+  for (const post of posts) {
+    const rkey = getStandardSiteDocumentRkey(post.slug);
+    const record = buildStandardSiteDocumentRecord({
+      post,
+      publicationUri: publication.uri,
+    });
+    const document = await putRecord({
+      accessJwt: session.accessJwt,
+      collection: STANDARD_SITE_DOCUMENT_COLLECTION,
+      record,
+      repo: session.did,
+      rkey,
+      serviceUrl,
+    });
+
+    nextData.documents[post.slug] = document.uri;
+    console.log(`Synced ${basename(post.slug)} -> ${document.uri}`);
+  }
+
+  await writeStandardSiteData(nextData);
+  console.log(
+    `Updated ${relative(projectRoot, standardSiteDataPath)} with ${posts.length} document AT-URIs.`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/src/data/standard-site.json
+++ b/src/data/standard-site.json
@@ -1,0 +1,4 @@
+{
+  "publicationUri": null,
+  "documents": {}
+}

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -10,6 +10,7 @@ import {
   SITE_URL,
   toAbsoluteUrl,
 } from "@/lib/seo";
+import { getPublicationUri } from "@/lib/standard-site";
 
 interface Props {
   pageTitle?: string;
@@ -21,6 +22,7 @@ interface Props {
   modifiedTime?: string | null;
   twitterCard?: "summary" | "summary_large_image";
   noIndex?: boolean;
+  standardSiteDocumentUri?: string | null;
 }
 
 const {
@@ -33,6 +35,7 @@ const {
   modifiedTime,
   twitterCard,
   noIndex,
+  standardSiteDocumentUri,
 } = Astro.props as Props;
 
 const siteUrl = Astro.site?.toString() ?? SITE_URL;
@@ -45,6 +48,7 @@ const resolvedCanonicalUrl = toAbsoluteUrl(
 const resolvedOgImage = toAbsoluteUrl(ogImage ?? "/icon.png", siteUrl);
 const resolvedOgType = ogType ?? "website";
 const resolvedTwitterCard = twitterCard ?? "summary_large_image";
+const standardSitePublicationUri = getPublicationUri();
 ---
 
 <html lang="ja">
@@ -71,6 +75,12 @@ const resolvedTwitterCard = twitterCard ?? "summary_large_image";
         <title>{resolvedTitle}</title>
         <meta name="description" content={resolvedDescription} />
         <link rel="canonical" href={resolvedCanonicalUrl} />
+        {standardSitePublicationUri && (
+          <link rel="site.standard.publication" href={standardSitePublicationUri} />
+        )}
+        {standardSiteDocumentUri && (
+          <link rel="site.standard.document" href={standardSiteDocumentUri} />
+        )}
         {noIndex && <meta name="robots" content="noindex,nofollow" />}
 
         <meta property="og:type" content={resolvedOgType} />

--- a/src/lib/standard-site.test.ts
+++ b/src/lib/standard-site.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildStandardSiteDocumentRecord,
+  buildStandardSitePublicationRecord,
+  createPublicationWellKnownResponse,
+  getDocumentUriForSlug,
+  getStandardSiteDocumentPath,
+  getStandardSiteDocumentRkey,
+  getSyncableStandardSitePosts,
+  isAtUri,
+  type StandardSiteDataFile,
+  type StandardSitePost,
+  toStandardSiteDateTime,
+  trimTrailingSlash,
+} from "./standard-site";
+
+const standardSiteData: StandardSiteDataFile = {
+  documents: {
+    draft: null,
+    visible: "at://did:plc:example/site.standard.document/visible",
+  },
+  publicationUri: "at://did:plc:example/site.standard.publication/self",
+};
+
+describe("Standard.site data helpers", () => {
+  test("detects AT-URIs", () => {
+    expect(isAtUri("at://did:plc:example/site.standard.document/post")).toBe(
+      true,
+    );
+    expect(isAtUri("https://example.com/post")).toBe(false);
+    expect(isAtUri(null)).toBe(false);
+  });
+
+  test("returns a document AT-URI for configured slugs only", () => {
+    expect(getDocumentUriForSlug("visible", standardSiteData)).toBe(
+      "at://did:plc:example/site.standard.document/visible",
+    );
+    expect(getDocumentUriForSlug("draft", standardSiteData)).toBeNull();
+    expect(getDocumentUriForSlug("missing", standardSiteData)).toBeNull();
+  });
+
+  test("creates publication well-known responses", async () => {
+    const configuredResponse =
+      createPublicationWellKnownResponse(standardSiteData);
+    expect(configuredResponse.status).toBe(200);
+    expect(await configuredResponse.text()).toBe(
+      "at://did:plc:example/site.standard.publication/self\n",
+    );
+
+    const missingResponse = createPublicationWellKnownResponse({
+      documents: {},
+      publicationUri: null,
+    });
+    expect(missingResponse.status).toBe(404);
+  });
+});
+
+describe("Standard.site record builders", () => {
+  test("builds publication records without a trailing URL slash", () => {
+    const record = buildStandardSitePublicationRecord({
+      description: "Description",
+      name: "Example Blog",
+      showInDiscover: false,
+      siteUrl: "https://example.com/",
+    });
+
+    expect(record).toEqual({
+      $type: "site.standard.publication",
+      description: "Description",
+      name: "Example Blog",
+      preferences: {
+        showInDiscover: false,
+      },
+      url: "https://example.com",
+    });
+  });
+
+  test("builds document records from local post metadata", () => {
+    const post: StandardSitePost = {
+      body: "# Heading\n\nHello **world**.",
+      category: "tech",
+      isUnlisted: false,
+      pubDate: "2025-01-02",
+      slug: "hello-world",
+      tags: ["Astro", "ATProto"],
+      title: "Hello World",
+      updDate: "2025-01-03",
+      url: "/blog/hello-world",
+    };
+
+    const record = buildStandardSiteDocumentRecord({
+      post,
+      publicationUri: standardSiteData.publicationUri ?? "",
+    });
+
+    expect(record).toEqual({
+      $type: "site.standard.document",
+      description: "Heading Hello world.",
+      path: "/blog/hello-world/",
+      publishedAt: "2025-01-02T00:00:00.000Z",
+      site: "at://did:plc:example/site.standard.publication/self",
+      tags: ["Astro", "ATProto"],
+      textContent: "Heading Hello world.",
+      title: "Hello World",
+      updatedAt: "2025-01-03T00:00:00.000Z",
+    });
+  });
+
+  test("filters syncable posts to listed local blog posts", () => {
+    const posts = [
+      {
+        pubDate: "2025-01-01",
+        slug: "listed",
+        tags: [],
+        title: "Listed",
+        url: "/blog/listed",
+      },
+      {
+        isUnlisted: true,
+        pubDate: "2025-01-01",
+        slug: "hidden",
+        tags: [],
+        title: "Hidden",
+        url: "/blog/hidden",
+      },
+      {
+        pubDate: "2025-01-01",
+        slug: "",
+        tags: [],
+        title: "External",
+        url: "https://example.com",
+      },
+    ] satisfies StandardSitePost[];
+
+    expect(
+      getSyncableStandardSitePosts(posts).map((post) => post.slug),
+    ).toEqual(["listed"]);
+  });
+});
+
+describe("Standard.site formatting helpers", () => {
+  test("formats paths, dates, record keys, and URLs", () => {
+    expect(getStandardSiteDocumentPath("example")).toBe("/blog/example/");
+    expect(getStandardSiteDocumentRkey("example-post_1")).toBe(
+      "example-post_1",
+    );
+    expect(toStandardSiteDateTime("2025-01-02")).toBe(
+      "2025-01-02T00:00:00.000Z",
+    );
+    expect(trimTrailingSlash("https://example.com///")).toBe(
+      "https://example.com",
+    );
+  });
+
+  test("rejects invalid record keys and dates", () => {
+    expect(() => getStandardSiteDocumentRkey("bad/key")).toThrow();
+    expect(() => toStandardSiteDateTime("not a date")).toThrow();
+  });
+});

--- a/src/lib/standard-site.ts
+++ b/src/lib/standard-site.ts
@@ -1,0 +1,177 @@
+import StandardSiteData from "../data/standard-site.json";
+import type { Post } from "../types/post";
+import {
+  createDescriptionFromMarkdown,
+  DEFAULT_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+  stripMarkdown,
+} from "./seo";
+
+export const STANDARD_SITE_PUBLICATION_COLLECTION = "site.standard.publication";
+export const STANDARD_SITE_DOCUMENT_COLLECTION = "site.standard.document";
+export const STANDARD_SITE_PUBLICATION_RKEY = "self";
+
+export interface StandardSiteDataFile {
+  publicationUri: string | null;
+  documents: Record<string, string | null | undefined>;
+}
+
+export interface StandardSitePublicationRecord {
+  $type: typeof STANDARD_SITE_PUBLICATION_COLLECTION;
+  url: string;
+  name: string;
+  description?: string;
+  preferences: {
+    showInDiscover: boolean;
+  };
+}
+
+export interface StandardSiteDocumentRecord {
+  $type: typeof STANDARD_SITE_DOCUMENT_COLLECTION;
+  site: string;
+  path: string;
+  title: string;
+  publishedAt: string;
+  description?: string;
+  tags?: string[];
+  textContent?: string;
+  updatedAt?: string;
+}
+
+export interface StandardSitePost extends Post {
+  body?: string | null;
+}
+
+const AT_URI_PATTERN = /^at:\/\/[^/\s]+\/[^/\s]+\/[^/\s]+$/;
+
+export function getStandardSiteData(): StandardSiteDataFile {
+  return StandardSiteData as StandardSiteDataFile;
+}
+
+export function isAtUri(value: unknown): value is string {
+  return typeof value === "string" && AT_URI_PATTERN.test(value);
+}
+
+export function getPublicationUri(
+  data: StandardSiteDataFile = getStandardSiteData(),
+): string | null {
+  return isAtUri(data.publicationUri) ? data.publicationUri : null;
+}
+
+export function getDocumentUriForSlug(
+  slug: string,
+  data: StandardSiteDataFile = getStandardSiteData(),
+): string | null {
+  const uri = data.documents[slug];
+  return isAtUri(uri) ? uri : null;
+}
+
+export function createPublicationWellKnownResponse(
+  data: StandardSiteDataFile = getStandardSiteData(),
+): Response {
+  const publicationUri = getPublicationUri(data);
+  if (!publicationUri) {
+    return new Response(
+      "Standard.site publication AT-URI is not configured.\n",
+      {
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+        },
+        status: 404,
+      },
+    );
+  }
+
+  return new Response(`${publicationUri}\n`, {
+    headers: {
+      "Cache-Control": "public, max-age=300",
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+export function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function getStandardSiteDocumentPath(slug: string): string {
+  return `/blog/${slug}/`;
+}
+
+export function getStandardSiteDocumentRkey(slug: string): string {
+  if (!/^[A-Za-z0-9._~:-]{1,512}$/.test(slug)) {
+    throw new Error(`Invalid AT Protocol record key for blog slug: ${slug}`);
+  }
+
+  return slug;
+}
+
+export function toStandardSiteDateTime(value: string): string {
+  const normalizedValue = /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? `${value}T00:00:00.000Z`
+    : value;
+  const date = new Date(normalizedValue);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid Standard.site datetime: ${value}`);
+  }
+
+  return date.toISOString();
+}
+
+export function buildStandardSitePublicationRecord({
+  description = DEFAULT_DESCRIPTION,
+  name = SITE_NAME,
+  showInDiscover = true,
+  siteUrl = SITE_URL,
+}: {
+  description?: string;
+  name?: string;
+  showInDiscover?: boolean;
+  siteUrl?: string;
+} = {}): StandardSitePublicationRecord {
+  return {
+    $type: STANDARD_SITE_PUBLICATION_COLLECTION,
+    description,
+    name,
+    preferences: {
+      showInDiscover,
+    },
+    url: trimTrailingSlash(siteUrl),
+  };
+}
+
+export function buildStandardSiteDocumentRecord({
+  post,
+  publicationUri,
+}: {
+  post: StandardSitePost;
+  publicationUri: string;
+}): StandardSiteDocumentRecord {
+  const body = post.body ?? "";
+  const description = createDescriptionFromMarkdown(body);
+  const textContent = stripMarkdown(body);
+  const record: StandardSiteDocumentRecord = {
+    $type: STANDARD_SITE_DOCUMENT_COLLECTION,
+    description,
+    path: getStandardSiteDocumentPath(post.slug),
+    publishedAt: toStandardSiteDateTime(post.pubDate),
+    site: publicationUri,
+    tags: post.tags,
+    textContent,
+    title: post.title,
+  };
+
+  if (post.updDate) {
+    record.updatedAt = toStandardSiteDateTime(post.updDate);
+  }
+
+  return record;
+}
+
+export function getSyncableStandardSitePosts(
+  posts: StandardSitePost[],
+): StandardSitePost[] {
+  return posts.filter((post) => Boolean(post.slug) && !post.isUnlisted);
+}

--- a/src/pages/.well-known/site.standard.publication.ts
+++ b/src/pages/.well-known/site.standard.publication.ts
@@ -1,0 +1,7 @@
+import { createPublicationWellKnownResponse } from "@/lib/standard-site";
+
+export const prerender = true;
+
+export function GET(): Response {
+  return createPublicationWellKnownResponse();
+}

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -5,12 +5,14 @@ import Base from "@/layouts/base.astro";
 import { markdownToHtmlWithToc } from "@/lib/markdown";
 import { getBlogPosts } from "@/lib/posts";
 import { createDescriptionFromMarkdown } from "@/lib/seo";
+import { getDocumentUriForSlug } from "@/lib/standard-site";
 
 interface Props {
   title: string;
   tags: string[];
   pubDate: string;
   updDate: string;
+  isUnlisted: boolean;
   body: string;
   showToc: boolean;
 }
@@ -27,6 +29,7 @@ export async function getStaticPaths() {
         tags: blog.tags,
         pubDate: blog.pubDate,
         updDate: blog.updDate,
+        isUnlisted: blog.isUnlisted,
         body: blog.body,
         showToc: blog.showToc,
       },
@@ -34,11 +37,16 @@ export async function getStaticPaths() {
   });
 }
 
-const { title, tags, pubDate, updDate, body, showToc } = Astro.props;
+const { title, tags, pubDate, updDate, isUnlisted, body, showToc } =
+  Astro.props;
 const { html: content, toc } = await markdownToHtmlWithToc(body);
 const canonicalUrl = `/blog/${Astro.params.slug}/`;
 const description = createDescriptionFromMarkdown(body);
 const ogImage = `/og/${Astro.params.slug}.png`;
+const standardSiteDocumentUri =
+  Astro.params.slug && !isUnlisted
+    ? getDocumentUriForSlug(Astro.params.slug)
+    : null;
 ---
 
 <Base
@@ -49,6 +57,7 @@ const ogImage = `/og/${Astro.params.slug}.png`;
     ogType="article"
     publishedTime={new Date(pubDate).toISOString()}
     modifiedTime={updDate ? new Date(updDate).toISOString() : null}
+    standardSiteDocumentUri={standardSiteDocumentUri}
 >
     <div class="mx-auto text-center">
         <div


### PR DESCRIPTION
## Summary
- add Standard.site publication/document helpers and static verification endpoint
- emit Standard.site publication/document `<link>` tags when AT-URIs are configured
- add a Bun sync script for creating/updating `site.standard.publication` and `site.standard.document` records through AT Protocol

## Testing
- `bun test`
- `bun run check:ci`
- `bun run standard-site:sync -- --dry-run`
- `bun run build`

Note: `bun run build` logs existing OGP fetch failures from link-card generation for some external URLs, but the build completes successfully.
