### PR TITLE
[codex] exclude unlisted posts from indexing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { extname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import partytown from "@astrojs/partytown";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
@@ -5,6 +8,60 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
 const DEFAULT_SITE_URL = "https://yashikota.com";
+const BLOG_CONTENT_DIR = fileURLToPath(
+  new URL("./src/content/blog/", import.meta.url),
+);
+
+const getMarkdownFiles = (dir) => {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return getMarkdownFiles(path);
+    }
+
+    return [".md", ".mdx"].includes(extname(entry.name)) ? [path] : [];
+  });
+};
+
+const getUnlistedBlogPaths = () => {
+  return getMarkdownFiles(BLOG_CONTENT_DIR).flatMap((path) => {
+    const content = readFileSync(path, "utf-8");
+    if (!/^isUnlisted:\s*true\s*$/m.test(content)) {
+      return [];
+    }
+
+    const slug = relative(BLOG_CONTENT_DIR, path)
+      .split(sep)
+      .join("/")
+      .replace(/\.(md|mdx)$/, "");
+
+    return [`/blog/${slug}/`];
+  });
+};
+
+const unlistedBlogPaths = new Set(getUnlistedBlogPaths());
+
+const createUnlistedHeadersIntegration = () => ({
+  name: "unlisted-headers",
+  hooks: {
+    "astro:build:done": ({ dir }) => {
+      const headers = [...unlistedBlogPaths]
+        .flatMap((path) => {
+          const pathWithoutTrailingSlash = path.replace(/\/$/, "");
+          return [
+            pathWithoutTrailingSlash,
+            "  X-Robots-Tag: noindex, nofollow, noarchive, nosnippet, noimageindex",
+            path,
+            "  X-Robots-Tag: noindex, nofollow, noarchive, nosnippet, noimageindex",
+          ];
+        })
+        .join("\n");
+
+      writeFileSync(fileURLToPath(new URL("_headers", dir)), `${headers}\n`);
+    },
+  },
+});
 
 const resolveSiteUrl = () => {
   const envSiteUrl = process.env.SITE_URL ?? process.env.PUBLIC_SITE_URL;
@@ -30,7 +87,13 @@ export default defineConfig({
         forward: ["dataLayer.push"],
       },
     }),
-    sitemap(),
+    sitemap({
+      filter: (page) => {
+        const { pathname } = new URL(page);
+        return !unlistedBlogPaths.has(pathname);
+      },
+    }),
+    createUnlistedHeadersIntegration(),
   ],
   vite: {
     plugins: [tailwindcss()],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,7 +27,9 @@ const getMarkdownFiles = (dir) => {
 const getUnlistedBlogPaths = () => {
   return getMarkdownFiles(BLOG_CONTENT_DIR).flatMap((path) => {
     const content = readFileSync(path, "utf-8");
-    if (!/^isUnlisted:\s*true\s*$/m.test(content)) {
+    const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    const frontmatter = frontmatterMatch ? frontmatterMatch[1] : "";
+    if (!/^isUnlisted:\s*true\s*$/m.test(frontmatter)) {
       return [];
     }
 
@@ -46,7 +48,13 @@ const createUnlistedHeadersIntegration = () => ({
   name: "unlisted-headers",
   hooks: {
     "astro:build:done": ({ dir }) => {
-      const headers = [...unlistedBlogPaths]
+      const headersFile = fileURLToPath(new URL("_headers", dir));
+      let existingContent = "";
+      try {
+        existingContent = readFileSync(headersFile, "utf-8");
+      } catch {}
+
+      const unlistedHeaders = [...unlistedBlogPaths]
         .flatMap((path) => {
           const pathWithoutTrailingSlash = path.replace(/\/$/, "");
           return [
@@ -58,7 +66,11 @@ const createUnlistedHeadersIntegration = () => ({
         })
         .join("\n");
 
-      writeFileSync(fileURLToPath(new URL("_headers", dir)), `${headers}\n`);
+      const headers = existingContent
+        ? `${existingContent.trim()}\n\n${unlistedHeaders}`
+        : unlistedHeaders;
+
+      writeFileSync(headersFile, `${headers}\n`);
     },
   },
 });
@@ -90,7 +102,10 @@ export default defineConfig({
     sitemap({
       filter: (page) => {
         const { pathname } = new URL(page);
-        return !unlistedBlogPaths.has(pathname);
+        const normalizedPathname = pathname.endsWith("/")
+          ? pathname
+          : `${pathname}/`;
+        return !unlistedBlogPaths.has(normalizedPathname);
       },
     }),
     createUnlistedHeadersIntegration(),

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow: /about
-
-Sitemap: https://yashikota.com/sitemap-index.xml

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -71,7 +71,7 @@ const resolvedTwitterCard = twitterCard ?? "summary_large_image";
         <title>{resolvedTitle}</title>
         <meta name="description" content={resolvedDescription} />
         <link rel="canonical" href={resolvedCanonicalUrl} />
-        {noIndex && <meta name="robots" content="noindex,nofollow" />}
+        {noIndex && <meta name="robots" content="noindex,nofollow,noarchive,nosnippet,noimageindex" />}
 
         <meta property="og:type" content={resolvedOgType} />
         <meta property="og:title" content={resolvedTitle} />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -13,6 +13,7 @@ interface Props {
   updDate: string;
   body: string;
   showToc: boolean;
+  isUnlisted: boolean;
 }
 
 export async function getStaticPaths() {
@@ -29,12 +30,14 @@ export async function getStaticPaths() {
         updDate: blog.updDate,
         body: blog.body,
         showToc: blog.showToc,
+        isUnlisted: blog.isUnlisted,
       },
     };
   });
 }
 
-const { title, tags, pubDate, updDate, body, showToc } = Astro.props;
+const { title, tags, pubDate, updDate, body, showToc, isUnlisted } =
+  Astro.props;
 const { html: content, toc } = await markdownToHtmlWithToc(body);
 const canonicalUrl = `/blog/${Astro.params.slug}/`;
 const description = createDescriptionFromMarkdown(body);
@@ -49,6 +52,7 @@ const ogImage = `/og/${Astro.params.slug}.png`;
     ogType="article"
     publishedTime={new Date(pubDate).toISOString()}
     modifiedTime={updDate ? new Date(updDate).toISOString() : null}
+    noIndex={isUnlisted}
 >
     <div class="mx-auto text-center">
         <div

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -7,14 +7,15 @@ import { getAllPosts } from "@/lib/posts";
 
 export async function getStaticPaths() {
   const allPosts = await getAllPosts();
+  const listedPosts = allPosts.filter((post) => !post.isUnlisted);
   const uniqueTags = [
     ...new Set(
-      allPosts.flatMap((post) => post.tags.map((tag) => tag.toLowerCase())),
+      listedPosts.flatMap((post) => post.tags.map((tag) => tag.toLowerCase())),
     ),
   ];
 
   return uniqueTags.map((tag) => {
-    const filteredPosts = allPosts.filter((post) =>
+    const filteredPosts = listedPosts.filter((post) =>
       post.tags.some((postTag) => postTag.toLowerCase() === tag),
     );
     return {

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -3,8 +3,9 @@ import { getBlogPosts } from "@/lib/posts";
 
 export const prerender = true;
 
-export const GET: APIRoute = async () => {
+export const GET: APIRoute = async (context) => {
   const posts = await getBlogPosts();
+  const siteUrl = context.site?.origin ?? "https://yashikota.com";
   const disallowRules = posts
     .filter((post) => post.isUnlisted)
     .flatMap((post) => [
@@ -17,7 +18,7 @@ export const GET: APIRoute = async () => {
       "User-agent: *",
       ...disallowRules,
       "",
-      "Sitemap: https://yashikota.com/sitemap-index.xml",
+      `Sitemap: ${siteUrl}/sitemap-index.xml`,
       "",
     ].join("\n"),
     {

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from "astro";
+import { getBlogPosts } from "@/lib/posts";
+
+export const prerender = true;
+
+export const GET: APIRoute = async () => {
+  const posts = await getBlogPosts();
+  const disallowRules = posts
+    .filter((post) => post.isUnlisted)
+    .flatMap((post) => [
+      `Disallow: /blog/${post.slug}`,
+      `Disallow: /blog/${post.slug}/`,
+    ]);
+
+  return new Response(
+    [
+      "User-agent: *",
+      ...disallowRules,
+      "",
+      "Sitemap: https://yashikota.com/sitemap-index.xml",
+      "",
+    ].join("\n"),
+    {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    },
+  );
+};


### PR DESCRIPTION
## Summary

- Generate robots.txt from isUnlisted blog posts so hidden posts are disallowed for all user agents.
- Exclude unlisted blog URLs from the generated sitemap and tag-page path discovery.
- Add noindex,nofollow,noarchive,nosnippet,noimageindex metadata and generated Cloudflare _headers entries for unlisted posts.

## Validation

- bun run check:ci
- bun test
- bun run build
- Verified generated dist/robots.txt, dist/_headers, sitemap exclusion for /blog/test/, no /og/test.png, and no /blog/test on listed surfaces.