### PR TITLE
Fix className type error in remark-youtube plugin

### DIFF
--- a/src/lib/remark-youtube.ts
+++ b/src/lib/remark-youtube.ts
@@ -46,7 +46,7 @@ const createIframeNode = (
   const { className, responsive, style } = options;
 
   const commonProps = {
-    className,
+    className: [className],
     src: `https://www.youtube.com/embed/${videoId}`,
     frameBorder: "0",
     allow:
@@ -106,7 +106,7 @@ const remarkYoutubePlugin =
         parent.data = {
           hName: "div",
           hProperties: {
-            className: "youtube-container",
+            className: ["youtube-container"],
           },
         };
 
@@ -124,7 +124,7 @@ const remarkYoutubePlugin =
         parent.data = {
           hName: "div",
           hProperties: {
-            className: "youtube-wrapper",
+            className: ["youtube-wrapper"],
             style: `position: relative; width: 100%; padding-bottom: ${ratio}%; height: 0; overflow: hidden;`,
           },
         };


### PR DESCRIPTION
## Summary

- `hProperties.className` は hast の `Properties` 型で `string[]` が要求されるのに `string` を渡しとったのを修正
- `commonProps.className`、`"youtube-container"`、`"youtube-wrapper"` の3箇所を配列に変更

## Test plan

- [ ] `astro check` でエラーが0件になることを確認 ✅