### PR TITLE
fix: parallelize link card OG fetch to reduce page load time

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,25 +53,44 @@ export default {
       return response;
     }
 
+    // Pass 1: collect all link card URLs without modifying the response
+    const urlsToFetch: { url: URL; displayUrl: string }[] = [];
+    await new HTMLRewriter()
+      .on('a[data-link-card="true"]', new LinkCardUrlCollector(urlsToFetch))
+      .transform(response.clone())
+      .text();
+
+    // Deduplicate and fetch all previews in parallel
+    const seen = new Set<string>();
+    const uniqueUrls = urlsToFetch.filter(({ url }) => {
+      const key = url.toString();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    const previews = await Promise.all(
+      uniqueUrls.map(({ url, displayUrl }) =>
+        getLinkPreview(url, displayUrl, ctx),
+      ),
+    );
+
+    const previewMap = new Map<string, LinkCardData>();
+    for (let i = 0; i < uniqueUrls.length; i++) {
+      previewMap.set(uniqueUrls[i].url.toString(), previews[i]);
+    }
+
+    // Pass 2: rewrite synchronously using precomputed map
     return new HTMLRewriter()
-      .on(
-        'a[data-link-card="true"]',
-        new LinkCardElementHandler({
-          ctx,
-        }),
-      )
+      .on('a[data-link-card="true"]', new LinkCardElementHandler(previewMap))
       .transform(response);
   },
 };
 
-class LinkCardElementHandler {
-  constructor(
-    private readonly options: {
-      ctx: ExecutionContextLike;
-    },
-  ) {}
+class LinkCardUrlCollector {
+  constructor(private readonly urls: { url: URL; displayUrl: string }[]) {}
 
-  async element(element: any): Promise<void> {
+  element(element: any): void {
     const rawUrl =
       element.getAttribute("data-link-card-url") ||
       element.getAttribute("href");
@@ -79,15 +98,24 @@ class LinkCardElementHandler {
       element.getAttribute("data-link-card-display-url") || "",
     );
     const url = tryParseHttpUrl(rawUrl);
-
-    if (!url) {
-      return;
+    if (url) {
+      this.urls.push({ url, displayUrl });
     }
+  }
+}
 
-    const preview = await getLinkPreview(url, displayUrl, this.options.ctx);
-    element.replace(renderLinkCardHtml(preview), {
-      html: true,
-    });
+class LinkCardElementHandler {
+  constructor(private readonly previewMap: Map<string, LinkCardData>) {}
+
+  element(element: any): void {
+    const rawUrl =
+      element.getAttribute("data-link-card-url") ||
+      element.getAttribute("href");
+    const url = tryParseHttpUrl(rawUrl);
+    if (!url) return;
+    const preview = this.previewMap.get(url.toString());
+    if (!preview) return;
+    element.replace(renderLinkCardHtml(preview), { html: true });
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -60,6 +60,10 @@ export default {
       .transform(response.clone())
       .text();
 
+    if (urlsToFetch.length === 0) {
+      return response;
+    }
+
     // Deduplicate and fetch all previews in parallel
     const seen = new Set<string>();
     const uniqueUrls = urlsToFetch.filter(({ url }) => {
@@ -71,7 +75,13 @@ export default {
 
     const previews = await Promise.all(
       uniqueUrls.map(({ url, displayUrl }) =>
-        getLinkPreview(url, displayUrl, ctx),
+        getLinkPreview(url, displayUrl, ctx).catch((error) => {
+          console.error(
+            `[worker] Failed to get link preview for ${url.toString()}:`,
+            error,
+          );
+          return createMinimalLinkCardData(url, displayUrl);
+        }),
       ),
     );
 


### PR DESCRIPTION
## Summary

- `worker.ts` のリンクカード処理が直列フェッチになっており、リンクカードが多い記事で著しく遅くなっていた問題を修正
- 2パスアプローチに変更: パス1でURL全収集 → `Promise.all()` で並列フェッチ → パス2で同期的にHTMLを書き換え
- 同一URLの重複フェッチも排除

## Root cause

`HTMLRewriter` の `element()` ハンドラが `async` だったため、各リンクカードのOGフェッチが直列実行されていた。リンクカードが10個あると最大50秒（5秒タイムアウト×10）かかる可能性があった。

## Fix

並列化後の待ち時間は最も遅い1リクエスト分のみ（最大5秒）に短縮。

## Test plan

- [ ] `bun test src/lib/link-card.test.ts` がパスすること
- [ ] リンクカードが複数ある記事（例: https://yashikota.com/blog/test/）でページ表示速度が改善されること